### PR TITLE
Feat: Add user role to JWT claims (#54)

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -107,9 +107,6 @@ func main() {
 	// User module - uses OAuth2 repository for Discord avatar URL generation
 	userDeps := user.ProvideUserDependencies(db, appRouter, oauth2Deps.OAuth2Repository)
 
-	// Set user query port for admin middleware after user dependencies are initialized
-	authInterceptor.SetUserQueryPort(userDeps.UserQueryRepo)
-
 	// Game module - provides Game, Team, and GameTeam management
 	gameDeps := game.ProvideGameDependencies(
 		db,

--- a/internal/auth/application/auth_service.go
+++ b/internal/auth/application/auth_service.go
@@ -37,7 +37,7 @@ func (s *AuthService) Login(req *dto.LoginRequest) (*dto.LoginResponse, error) {
 		return nil, err
 	}
 
-	token, err := s.tokenService.GenerateTokenPair(user.Id)
+	token, err := s.tokenService.GenerateTokenPair(user.Id, string(user.Role))
 	if err != nil {
 		return nil, err
 	}
@@ -72,12 +72,17 @@ func (s *AuthService) Refresh(req dto.RefreshRequest) (*dto.RefreshResponse, err
 		return nil, err
 	}
 
+	claims, err := s.tokenService.Validate(jwtToken.TokenTypeRefresh, req.RefreshToken)
+	if err != nil {
+		return nil, err
+	}
+
 	err = s.refreshTokenCachePort.Delete(&req.RefreshToken)
 	if err != nil {
 		return nil, err
 	}
 
-	token, err := s.tokenService.GenerateTokenPair(refreshToken.UserID)
+	token, err := s.tokenService.GenerateTokenPair(refreshToken.UserID, claims.Role)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/global/security/jwt/application/jwt_token_service.go
+++ b/internal/global/security/jwt/application/jwt_token_service.go
@@ -20,13 +20,13 @@ func (t *TokenService) RegisterStrategy(strategy domain.TokenStrategy) {
 	t.strategies[strategy.GetTokenType()] = strategy
 }
 
-func (t *TokenService) Generate(tokenType domain.TokenType, userID int64) (string, error) {
+func (t *TokenService) Generate(tokenType domain.TokenType, userID int64, role string) (string, error) {
 	strategy, exists := t.strategies[tokenType]
 	if !exists {
 		return "", errors.New("token strategy not found")
 	}
 
-	return strategy.Generate(userID)
+	return strategy.Generate(userID, role)
 }
 
 func (t *TokenService) GetTTL(tokenType domain.TokenType) *int64 {
@@ -45,13 +45,13 @@ func (t *TokenService) Validate(tokenType domain.TokenType, tokenString string) 
 	return strategy.Validate(tokenString)
 }
 
-func (t *TokenService) GenerateTokenPair(userID int64) (*dto.TokenResponse, error) {
-	accessToken, err := t.Generate(domain.TokenTypeAccess, userID)
+func (t *TokenService) GenerateTokenPair(userID int64, role string) (*dto.TokenResponse, error) {
+	accessToken, err := t.Generate(domain.TokenTypeAccess, userID, role)
 	if err != nil {
 		return nil, err
 	}
 
-	refreshToken, err := t.Generate(domain.TokenTypeRefresh, userID)
+	refreshToken, err := t.Generate(domain.TokenTypeRefresh, userID, role)
 	if err != nil {
 		return nil, err
 	}
@@ -68,5 +68,5 @@ func (t *TokenService) RefreshAccessToken(refreshToken string) (string, error) {
 		return "", err
 	}
 
-	return t.Generate(domain.TokenTypeAccess, claims.UserID)
+	return t.Generate(domain.TokenTypeAccess, claims.UserID, claims.Role)
 }

--- a/internal/global/security/jwt/domain/token_strategy.go
+++ b/internal/global/security/jwt/domain/token_strategy.go
@@ -12,7 +12,7 @@ const (
 )
 
 type TokenStrategy interface {
-	Generate(userID int64) (string, error)
+	Generate(userID int64, role string) (string, error)
 	GetTTL() *int64
 	Validate(tokenString string) (*Claims, error)
 	GetTokenType() TokenType
@@ -20,6 +20,7 @@ type TokenStrategy interface {
 
 type Claims struct {
 	UserID    int64     `json:"user_id"`
+	Role      string    `json:"role"`
 	TokenType TokenType `json:"token_type"`
 	jwt.RegisteredClaims
 }

--- a/internal/global/security/jwt/infra/access_token_strategy.go
+++ b/internal/global/security/jwt/infra/access_token_strategy.go
@@ -22,11 +22,12 @@ func NewAccessTokenStrategy(config *domain.Token) *AccessTokenStrategy {
 	}
 }
 
-func (s *AccessTokenStrategy) Generate(userID int64) (string, error) {
+func (s *AccessTokenStrategy) Generate(userID int64, role string) (string, error) {
 	now := time.Now()
 
 	claims := &domain.Claims{
 		UserID:    userID,
+		Role:      role,
 		TokenType: domain.TokenTypeAccess,
 		RegisteredClaims: jwt.RegisteredClaims{
 			ExpiresAt: jwt.NewNumericDate(now.Add(s.duration)),

--- a/internal/global/security/jwt/infra/refresh_token_strategy.go
+++ b/internal/global/security/jwt/infra/refresh_token_strategy.go
@@ -22,11 +22,12 @@ func NewRefreshTokenStrategy(config *domain.Token) *RefreshTokenStrategy {
 	}
 }
 
-func (s *RefreshTokenStrategy) Generate(userID int64) (string, error) {
+func (s *RefreshTokenStrategy) Generate(userID int64, role string) (string, error) {
 	now := time.Now()
 
 	claims := &domain.Claims{
 		UserID:    userID,
+		Role:      role,
 		TokenType: domain.TokenTypeRefresh,
 		RegisteredClaims: jwt.RegisteredClaims{
 			ExpiresAt: jwt.NewNumericDate(now.Add(s.duration)),

--- a/internal/oauth2/application/port/oauth2_user_port.go
+++ b/internal/oauth2/application/port/oauth2_user_port.go
@@ -4,4 +4,5 @@ import "github.com/FOR-GAMERS/GAMERS-BE/internal/user/domain"
 
 type OAuth2UserPort interface {
 	SaveRandomUser(user *domain.User) error
+	FindById(id int64) (*domain.User, error)
 }

--- a/internal/user/infra/persistence/adapter/oauth2_user_adapter.go
+++ b/internal/user/infra/persistence/adapter/oauth2_user_adapter.go
@@ -37,6 +37,15 @@ func (a *OAuth2UserAdapter) SaveRandomUser(user *domain.User) error {
 	return nil
 }
 
+func (a *OAuth2UserAdapter) FindById(id int64) (*domain.User, error) {
+	var user domain.User
+	result := a.db.First(&user, id)
+	if result.Error != nil {
+		return nil, result.Error
+	}
+	return &user, nil
+}
+
 func (a *OAuth2UserAdapter) save(user *domain.User) error {
 	result := a.db.Create(user)
 	if result.Error != nil {


### PR DESCRIPTION
## Summary
- Add `Role` field to JWT Claims so `RequireAdmin` middleware can authorize requests based on the token itself, eliminating a DB query on every admin-protected endpoint
- Remove `UserQueryPort` dependency from `AuthMiddleware` to simplify middleware structure
- Add `FindById` method to `OAuth2UserPort` for looking up existing user roles during Discord OAuth2 login

## Changes
- Add `Role string` field to `Claims` struct
- Change `TokenStrategy.Generate()` signature to `(userID int64, role string)`
- Propagate role through `TokenService.Generate()`, `GenerateTokenPair()`, and `RefreshAccessToken()`
- Pass user role in `AuthService.Login()` and `AuthService.Refresh()`
- Pass user role in `DiscordService.HandleDiscordCallback()` for both new and existing users
- Store `userRole` in gin context within `RequireAuth()`
- Replace DB lookup in `RequireAdmin()` with context-based role check
- Remove `SetUserQueryPort()` call from `cmd/server.go`

## Test plan
- [x] `make build` compiles without errors
- [x] Decode JWT issued after login and verify `role` field is present
- [x] Admin user login → admin API call succeeds
- [x] Regular user login → admin API call returns 403
- [x] Discord OAuth2 login → JWT includes role
- [x] Refresh token → new access token retains role

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)